### PR TITLE
Fix: conversion to string fixes the issue

### DIFF
--- a/src/lib/ynput/lib/logging/AyonLogger.hpp
+++ b/src/lib/ynput/lib/logging/AyonLogger.hpp
@@ -169,7 +169,7 @@ class AyonLogger {
             if (!filepath.empty()) {
                 this->m_EnableFileLogging = true;
                 this->m_FileLogger = spdlog::basic_logger_mt<spdlog::async_factory>(
-                    filepath + "fileLogger", std::filesystem::absolute(filepath.c_str()));
+                    filepath + "fileLogger", std::filesystem::absolute(filepath.c_str()).string());
 
                 this->m_FileLogger->set_pattern(
                     "{\"timestamp\":\"%Y-%m-%d %H:%M:%S.%e\",\"level\":\"%l\",\"Thread "


### PR DESCRIPTION
## Changelog Description
Easy conversion to string of one argument in spdlog::basic_logger_mt function call. This was breaking the build mainly on windows.

Tested on Ubuntu, Windows, Alma linux.

The argument should really be std::string based on https://github.com/gabime/spdlog/blob/faa0a7a9c5a3550ed5461fab7d8e31c37fd1a2ef/include/spdlog/sinks/basic_file_sink.h#L46 and https://github.com/gabime/spdlog/blob/faa0a7a9c5a3550ed5461fab7d8e31c37fd1a2ef/include/spdlog/common.h#L137