### PR TITLE
Feature/fix project roots windows

### DIFF
--- a/src/lib/ynput/core/iostd/envVarHelpers.hpp
+++ b/src/lib/ynput/core/iostd/envVarHelpers.hpp
@@ -86,7 +86,7 @@ getEnvArray(const std::string &envKey) {
 
 /**
  * @brief split an environment key into a std::map
- * delimiter = `,` key value definition = {key}:{value}
+ * delimiter = `,` key value definition = {key}={value}
  *
  * @param envKey
  * @return
@@ -101,8 +101,13 @@ getEnvMap(const std::string &envKey) {
     std::vector<std::string> dirtyArrayItems = split(envKeyVal, ',');
 
     for (std::string &dirtyItem: dirtyArrayItems) {
-        std::vector<std::string> dirtySplitItems = split(dirtyItem, ':');
-        envMap.emplace(std::make_pair(cleanEnvKey(dirtySplitItems.at(0)), cleanEnvKey(dirtySplitItems.at(1))));
+        // Split on first '=' only — colon ':' breaks Windows drive letters (e.g. work=W:)
+        auto eqPos = dirtyItem.find('=');
+        if (eqPos != std::string::npos) {
+            std::string key = dirtyItem.substr(0, eqPos);
+            std::string val = dirtyItem.substr(eqPos + 1);
+            envMap.emplace(std::make_pair(cleanEnvKey(key), cleanEnvKey(val)));
+        }
     }
     return envMap;
 };

--- a/src/lib/ynput/tool/ayon/rootHelpers.hpp
+++ b/src/lib/ynput/tool/ayon/rootHelpers.hpp
@@ -1,10 +1,12 @@
 #ifndef TOOL_AYON_ROT_HELPERS_DEF
 #define TOOL_AYON_ROT_HELPERS_DEF
 
+#include "../../../../NameSpaceDef/namespaces.hpp"
+
 #include <algorithm>
 #include <regex>
 #include <string>
-#include "../../../../NameSpaceDef/namespaces.hpp"
+#include <unordered_map>
 
 /**
  * @brief allows to replace the {root[xxx]} key from an Ayon resolver endpoint with the local root overwrites
@@ -26,12 +28,11 @@ rootReplace(const std::string &rootLessPath, const std::unordered_map<std::strin
         std::string siteRootOverwriteName = matchea.str(0);
 
         std::smatch matcheb;
-        std::regex rootBraketPattern("\\[(.*?)\\]");
-        if (std::regex_search(rootLessPath, matcheb, rootBraketPattern)) {
-            std::string breakedString = matcheb.str(0);
-            breakedString = breakedString.substr(1, breakedString.length() - 2);
+        std::regex rootBracketPattern("\\[(.*?)\\]");
+        if (std::regex_search(siteRootOverwriteName, matcheb, rootBracketPattern)) {
+            std::string key = matcheb.str(1);
             try {
-                std::string replacement = siteRoots.at(breakedString);
+                std::string replacement = siteRoots.at(key);
                 rootedPath = std::regex_replace(rootLessPath, rootFindPattern, replacement);
                 std::replace(rootedPath.begin(), rootedPath.end(), '\\', '/');
                 return rootedPath;

--- a/src/lib/ynput/tool/ayon/rootHelpers.hpp
+++ b/src/lib/ynput/tool/ayon/rootHelpers.hpp
@@ -1,6 +1,7 @@
 #ifndef TOOL_AYON_ROT_HELPERS_DEF
 #define TOOL_AYON_ROT_HELPERS_DEF
 
+#include <algorithm>
 #include <regex>
 #include <string>
 #include "../../../../NameSpaceDef/namespaces.hpp"
@@ -32,6 +33,7 @@ rootReplace(const std::string &rootLessPath, const std::unordered_map<std::strin
             try {
                 std::string replacement = siteRoots.at(breakedString);
                 rootedPath = std::regex_replace(rootLessPath, rootFindPattern, replacement);
+                std::replace(rootedPath.begin(), rootedPath.end(), '\\', '/');
                 return rootedPath;
             }
             catch (std::out_of_range &e) {


### PR DESCRIPTION
## Changelog Description
Change env var key definition from {key}:{value} to {key}={value} to avoid windows drive letters breaking split logic

## Additional review information
This may be unique to how our network paths are mapped, but I'm sure we're not the only studio mapping network paths to drives on windows.

## Testing notes:
This is easy to spot if you try resolve a Windows drive letter with a colon ("W:" for example)
