### PR TITLE
Logging Enhancements

### DIFF
--- a/src/lib/ynput/core/iostd/envVarHelpers.hpp
+++ b/src/lib/ynput/core/iostd/envVarHelpers.hpp
@@ -2,6 +2,7 @@
 #define YNPUT_ENV_VAR_HELPER
 
 #include "../../../../NameSpaceDef/namespaces.hpp"
+#include "../../lib/logging/AyonLogger.hpp"
 #include <cstdlib>
 #include <map>
 #include <string>
@@ -17,11 +18,19 @@
 YNPUT_CORE_IOSTD_NAMESPACE_OPEN
 std::string
 getEnvKey(const std::string &envKey) {
+    auto & logger = AyonLogger::getInstance();
+    static const std::string kLogKeyName = "getEnvKey";
+    static const bool kRegistered = logger.registerLoggingKey(kLogKeyName);
+    (void)kRegistered;
+
+    auto logKey = logger.key(kLogKeyName);
     const char* charEnvKey = std::getenv(envKey.c_str());
     if (charEnvKey != nullptr) {
         std::string strEnvKey(charEnvKey);
+        logger.info(logKey, "Loaded environment key '{}'", envKey);
         return strEnvKey;
     }
+    logger.warn(logKey, "Environment key '{}' was not found", envKey);
     return "";
 };
 
@@ -33,12 +42,20 @@ getEnvKey(const std::string &envKey) {
  */
 std::string
 cleanEnvKey(std::string &dirtyKey) {
+    auto & logger = AyonLogger::getInstance();
+    static const std::string kLogKeyName = "cleanEnvKey";
+    static const bool kRegistered = logger.registerLoggingKey(kLogKeyName);
+    (void)kRegistered;
+
+    auto logKey = logger.key(kLogKeyName);
     auto start = dirtyKey.find_first_not_of(" \t\n\r\f\v");
     if (start == std::string::npos) {
+        logger.warn(logKey, "Environment key value was empty after cleanup");
         return "";
     }
     auto end = dirtyKey.find_last_not_of(" \t\n\r\f\v");
 
+    logger.info(logKey, "Cleaned environment key value");
     return dirtyKey.substr(start, end - start + 1);
 };
 
@@ -52,6 +69,12 @@ cleanEnvKey(std::string &dirtyKey) {
  */
 std::vector<std::string>
 split(const std::string &str, char delimiter) {
+    auto & logger = AyonLogger::getInstance();
+    static const std::string kLogKeyName = "splitEnvValue";
+    static const bool kRegistered = logger.registerLoggingKey(kLogKeyName);
+    (void)kRegistered;
+
+    auto logKey = logger.key(kLogKeyName);
     std::vector<std::string> tokens;
     std::stringstream ss(str);
     std::string token;
@@ -60,6 +83,7 @@ split(const std::string &str, char delimiter) {
         tokens.push_back(token);
     }
 
+    logger.info(logKey, "Split environment value into {} token(s)", tokens.size());
     return tokens;
 }
 
@@ -71,9 +95,16 @@ split(const std::string &str, char delimiter) {
  */
 std::vector<std::string>
 getEnvArray(const std::string &envKey) {
+    auto & logger = AyonLogger::getInstance();
+    static const std::string kLogKeyName = "getEnvArray";
+    static const bool kRegistered = logger.registerLoggingKey(kLogKeyName);
+    (void)kRegistered;
+
+    auto logKey = logger.key(kLogKeyName);
     std::string envKeyVal = getEnvKey(envKey);
     std::vector<std::string> arrayItems;
     if (envKeyVal.empty()) {
+        logger.warn(logKey, "Environment array key '{}' was empty", envKey);
         return arrayItems;
     }
     arrayItems = split(envKeyVal, ',');
@@ -81,6 +112,7 @@ getEnvArray(const std::string &envKey) {
     for (std::string &dirtyItem: arrayItems) {
         dirtyItem = cleanEnvKey(dirtyItem);
     }
+    logger.info(logKey, "Loaded environment array '{}' with {} item(s)", envKey, arrayItems.size());
     return arrayItems;
 };
 
@@ -93,9 +125,16 @@ getEnvArray(const std::string &envKey) {
  */
 std::map<std::string, std::string>
 getEnvMap(const std::string &envKey) {
+    auto & logger = AyonLogger::getInstance();
+    static const std::string kLogKeyName = "getEnvMap";
+    static const bool kRegistered = logger.registerLoggingKey(kLogKeyName);
+    (void)kRegistered;
+
+    auto logKey = logger.key(kLogKeyName);
     std::string envKeyVal = getEnvKey(envKey);
     std::map<std::string, std::string> envMap;
     if (envKeyVal.empty()) {
+        logger.warn(logKey, "Environment map key '{}' was empty", envKey);
         return envMap;
     }
     std::vector<std::string> dirtyArrayItems = split(envKeyVal, ',');
@@ -109,6 +148,7 @@ getEnvMap(const std::string &envKey) {
             envMap.emplace(std::make_pair(cleanEnvKey(key), cleanEnvKey(val)));
         }
     }
+    logger.info(logKey, "Loaded environment map '{}' with {} item(s)", envKey, envMap.size());
     return envMap;
 };
 YNPUT_CORE_IOSTD_NAMESPACE_CLOSE

--- a/src/lib/ynput/lib/logging/AyonLogger.hpp
+++ b/src/lib/ynput/lib/logging/AyonLogger.hpp
@@ -194,7 +194,9 @@ private:
     }
 
     ~AyonLogger() {
-        flush();
+        if (m_consoleLogger) {
+            m_consoleLogger->flush();
+        }
         if (m_enableFileLogging && m_fileLogger) {
             spdlog::drop(m_fileLogger->name());
             m_fileLogger.reset();

--- a/src/lib/ynput/lib/logging/AyonLogger.hpp
+++ b/src/lib/ynput/lib/logging/AyonLogger.hpp
@@ -53,6 +53,7 @@ public:
             if (!spdlog::thread_pool()) {
                 spdlog::init_thread_pool(8192, 1);
             }
+            m_fileLoggerThreadPool = spdlog::thread_pool();
 
             auto abs_path = std::filesystem::absolute(filepath).string();
             std::string logger_name = std::string("AyonLogger_file_logger_") + abs_path;
@@ -175,7 +176,7 @@ public:
     // Explicit flush for async loggers
     void flush() {
         if (m_consoleLogger) m_consoleLogger->flush();
-        if (m_enableFileLogging && m_fileLogger) m_fileLogger->flush();
+        if (canUseAsyncFileLogger()) m_fileLogger->flush();
     }
 
 private:
@@ -194,13 +195,15 @@ private:
 
     ~AyonLogger() {
         flush();
-        if (m_consoleLogger) {
-            spdlog::drop(m_consoleLogger->name());
-            m_consoleLogger.reset();
-        }
         if (m_enableFileLogging && m_fileLogger) {
             spdlog::drop(m_fileLogger->name());
             m_fileLogger.reset();
+            m_fileLoggerThreadPool.reset();
+            m_enableFileLogging = false;
+        }
+        if (m_consoleLogger) {
+            spdlog::drop(m_consoleLogger->name());
+            m_consoleLogger.reset();
         }
     }
 
@@ -212,8 +215,12 @@ private:
         if (m_consoleLogger)
             m_consoleLogger->log(lvl, fmt, std::forward<Args>(args)...);
 
-        if (m_enableFileLogging && m_fileLogger)
+        if (canUseAsyncFileLogger())
             m_fileLogger->log(lvl, fmt, std::forward<Args>(args)...);
+    }
+
+    bool canUseAsyncFileLogger() const {
+        return m_enableFileLogging && m_fileLogger && !m_fileLoggerThreadPool.expired();
     }
 
     void setLevel(spdlog::level::level_enum lvl, bool applyToFile) {
@@ -225,6 +232,7 @@ private:
 
     std::shared_ptr<spdlog::logger> m_consoleLogger;
     std::shared_ptr<spdlog::logger> m_fileLogger;
+    std::weak_ptr<spdlog::details::thread_pool> m_fileLoggerThreadPool;
 
     bool m_enableFileLogging{false};
     std::mutex m_initMutex;

--- a/src/lib/ynput/tool/ayon/rootHelpers.hpp
+++ b/src/lib/ynput/tool/ayon/rootHelpers.hpp
@@ -2,6 +2,7 @@
 #define TOOL_AYON_ROT_HELPERS_DEF
 
 #include "../../../../NameSpaceDef/namespaces.hpp"
+#include "../../lib/logging/AyonLogger.hpp"
 
 #include <algorithm>
 #include <regex>
@@ -17,9 +18,15 @@
  */
 YNPUT_TOOL_AYON_NAMESPACE_OPEN
 
-// TODO after we implemented a singleton logger we will Re implement logging into this function
 std::string
 rootReplace(const std::string &rootLessPath, const std::unordered_map<std::string, std::string> &siteRoots) {
+    auto & logger = AyonLogger::getInstance();
+    static const std::string kLogKeyName = "rootReplace";
+    static const bool kRegistered = logger.registerLoggingKey(kLogKeyName);
+    (void)kRegistered;
+
+    auto logKey = logger.key(kLogKeyName);
+
     std::string rootedPath;
 
     std::smatch matchea;
@@ -38,6 +45,7 @@ rootReplace(const std::string &rootLessPath, const std::unordered_map<std::strin
                 return rootedPath;
             }
             catch (std::out_of_range &e) {
+                logger.warn(logKey, "Could not find site root '{}' for path '{}'", key, rootLessPath);
                 return rootLessPath;
             }
         }


### PR DESCRIPTION
### Logging Enhancements

* Added structured logging to all major functions in `envVarHelpers.hpp` (`getEnvKey`, `cleanEnvKey`, `split`, `getEnvArray`, `getEnvMap`) to record successful operations and warnings for missing or empty environment variables. Each function now registers a logging key and uses the singleton `AyonLogger` instance for consistent log output. [[1]](diffhunk://#diff-01e15975197938bae49d598c66bd22bcda293c7750325d9cfbd785ef3ebce398R5) [[2]](diffhunk://#diff-01e15975197938bae49d598c66bd22bcda293c7750325d9cfbd785ef3ebce398R21-R33) [[3]](diffhunk://#diff-01e15975197938bae49d598c66bd22bcda293c7750325d9cfbd785ef3ebce398R45-R58) [[4]](diffhunk://#diff-01e15975197938bae49d598c66bd22bcda293c7750325d9cfbd785ef3ebce398R72-R77) [[5]](diffhunk://#diff-01e15975197938bae49d598c66bd22bcda293c7750325d9cfbd785ef3ebce398R86) [[6]](diffhunk://#diff-01e15975197938bae49d598c66bd22bcda293c7750325d9cfbd785ef3ebce398R98-R115) [[7]](diffhunk://#diff-01e15975197938bae49d598c66bd22bcda293c7750325d9cfbd785ef3ebce398R128-R137) [[8]](diffhunk://#diff-01e15975197938bae49d598c66bd22bcda293c7750325d9cfbd785ef3ebce398R151)
* Integrated logging into the `rootReplace` function in `rootHelpers.hpp`, including warnings when a site root cannot be found. [[1]](diffhunk://#diff-10cb8c62c00c3f0d743b91bd348f31ee01639de054629fa764df8694a5a339fbR5) [[2]](diffhunk://#diff-10cb8c62c00c3f0d743b91bd348f31ee01639de054629fa764df8694a5a339fbL20-R29) [[3]](diffhunk://#diff-10cb8c62c00c3f0d743b91bd348f31ee01639de054629fa764df8694a5a339fbR48)

### Logger Implementation Improvements

* Updated `AyonLogger` to use a `std::weak_ptr` for the file logger's thread pool, ensuring that file logging is only attempted if the thread pool is still valid. Introduced the `canUseAsyncFileLogger()` helper for this purpose. [[1]](diffhunk://#diff-fe7b88c6107ac82d32abcd4bb1009eaaed4b2bcb9e50d7677d7d24522b0e2cc9R56) [[2]](diffhunk://#diff-fe7b88c6107ac82d32abcd4bb1009eaaed4b2bcb9e50d7677d7d24522b0e2cc9L215-R227) [[3]](diffhunk://#diff-fe7b88c6107ac82d32abcd4bb1009eaaed4b2bcb9e50d7677d7d24522b0e2cc9R237)
* Improved resource cleanup in the `AyonLogger` destructor by explicitly flushing and resetting loggers and thread pools, and guarding file logging operations to prevent issues if resources are already released. [[1]](diffhunk://#diff-fe7b88c6107ac82d32abcd4bb1009eaaed4b2bcb9e50d7677d7d24522b0e2cc9L178-R179) [[2]](diffhunk://#diff-fe7b88c6107ac82d32abcd4bb1009eaaed4b2bcb9e50d7677d7d24522b0e2cc9L196-R208)