### PR TITLE
Add new methods for setting log levels

### DIFF
--- a/src/lib/ynput/lib/logging/AyonLogger.hpp
+++ b/src/lib/ynput/lib/logging/AyonLogger.hpp
@@ -157,6 +157,22 @@ public:
             log(spdlog::level::critical, fmt, std::forward<Args>(args)...);
     }
 
+    void setLogLevel(spdlog::level::level_enum lvl, bool applyToFile = false) {
+        setLevel(lvl, applyToFile);
+    }
+
+    void setLogLevel(const std::string& levelStr, bool applyToFile = false) {
+        auto lvl = spdlog::level::from_str(levelStr);
+        setLevel(lvl, applyToFile);
+    }
+
+    void setLogLevelFromEnv(const std::string& envKey = "AYON_USD_RESOLVER_LOG_LVL", bool applyToFile = false) {
+        auto envVal = std::getenv(envKey.c_str());
+        if (envVal) {
+            setLogLevel(std::string(envVal), applyToFile);
+        }
+    }
+
     void setLogLevelInfo(bool applyToFile = false) {
         setLevel(spdlog::level::info, applyToFile);
     }

--- a/src/lib/ynput/lib/logging/AyonLogger.hpp
+++ b/src/lib/ynput/lib/logging/AyonLogger.hpp
@@ -5,6 +5,8 @@
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <iostream>
 #include <memory>
@@ -162,7 +164,13 @@ public:
     }
 
     void setLogLevel(const std::string& levelStr, bool applyToFile = false) {
-        auto lvl = spdlog::level::from_str(levelStr);
+        auto normalizedLevel = levelStr;
+        std::transform(
+            normalizedLevel.begin(),
+            normalizedLevel.end(),
+            normalizedLevel.begin(),
+            ::tolower);
+        auto lvl = spdlog::level::from_str(normalizedLevel);
         setLevel(lvl, applyToFile);
     }
 

--- a/src/lib/ynput/lib/logging/AyonLogger.hpp
+++ b/src/lib/ynput/lib/logging/AyonLogger.hpp
@@ -170,6 +170,8 @@ public:
         auto envVal = std::getenv(envKey.c_str());
         if (envVal) {
             setLogLevel(std::string(envVal), applyToFile);
+            std::cout << "[AyonLogger] Log level set from environment variable '" << envKey 
+                      << "' with value '" << envVal << "'" << std::endl;
         }
     }
 


### PR DESCRIPTION
## Changelog Description
This pull request adds new methods to the `AyonLogger` class to provide more flexible and convenient ways to set the logging level, including support for setting the log level from a string or an environment variable.

**Logging level configuration improvements:**

* Added `setLogLevel(spdlog::level::level_enum lvl, bool applyToFile = false)` to set the log level directly using the `spdlog` enum.
* Added `setLogLevel(const std::string& levelStr, bool applyToFile = false)` to set the log level using a string (e.g., "info", "debug").
* Added `setLogLevelFromEnv(const std::string& envKey = "AYON_USD_RESOLVER_LOG_LVL", bool applyToFile = false)` to set the log level from an environment variable.

## Additional review information
This will enable to fix [this issue](https://github.com/ynput/ayon-usd-resolver/issues/71) in resolver.

## Testing notes:
1. Test in resolver PR