### PR TITLE
fix of segfault - adjustment in getting the logger instance

### DIFF
--- a/src/lib/ynput/lib/logging/AyonLogger.hpp
+++ b/src/lib/ynput/lib/logging/AyonLogger.hpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -30,8 +31,10 @@
 class AyonLogger {
 public:
     static AyonLogger& getInstance() {
-        static AyonLogger instance;
-        return instance;
+        // Keep the logger alive until process exit. DLL-local static destruction
+        // order in host applications can be unsafe during shutdown on Windows.
+        static auto* instance = new AyonLogger();
+        return *instance;
     }
 
     // Explicit Initialization for File Logging
@@ -50,6 +53,14 @@ public:
 
         std::cout << "[AyonLogger] Initializing async file logger at: " << filepath << std::endl;
         try {
+            auto abs_path = std::filesystem::absolute(filepath).string();
+            {
+                std::ofstream probe(abs_path, std::ios::app);
+                if (!probe.is_open()) {
+                    throw std::runtime_error("Failed opening file " + abs_path + " for writing");
+                }
+            }
+
             // Initialize async thread pool only if not already initialized
             // (another component may have already called spdlog::init_thread_pool)
             if (!spdlog::thread_pool()) {
@@ -57,7 +68,6 @@ public:
             }
             m_fileLoggerThreadPool = spdlog::thread_pool();
 
-            auto abs_path = std::filesystem::absolute(filepath).string();
             std::string logger_name = std::string("AyonLogger_file_logger_") + abs_path;
 
             m_fileLogger = spdlog::basic_logger_mt<spdlog::async_factory>(
@@ -169,7 +179,7 @@ public:
             normalizedLevel.begin(),
             normalizedLevel.end(),
             normalizedLevel.begin(),
-            ::tolower);
+            [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
         auto lvl = spdlog::level::from_str(normalizedLevel);
         setLevel(lvl, applyToFile);
     }
@@ -178,7 +188,7 @@ public:
         auto envVal = std::getenv(envKey.c_str());
         if (envVal) {
             setLogLevel(std::string(envVal), applyToFile);
-            std::cout << "[AyonLogger] Log level set from environment variable '" << envKey 
+            std::cout << "[AyonLogger] Log level set from environment variable '" << envKey
                       << "' with value '" << envVal << "'" << std::endl;
         }
     }


### PR DESCRIPTION
## Changelog Description
This pull request updates the `AyonLogger` class to improve the reliability of singleton destruction, enhance file logging initialization, and fix a minor bug in log level normalization.

## Testing notes:
1. run Maya or Houdini
2. test the USD resolver
3. quit the DCC
4. check if any errors occurred during the exit