### PR TITLE
Release merge

### DIFF
--- a/src/lib/ynput/lib/logging/AyonLogger.hpp
+++ b/src/lib/ynput/lib/logging/AyonLogger.hpp
@@ -157,6 +157,22 @@ public:
             log(spdlog::level::critical, fmt, std::forward<Args>(args)...);
     }
 
+    void setLogLevel(spdlog::level::level_enum lvl, bool applyToFile = false) {
+        setLevel(lvl, applyToFile);
+    }
+
+    void setLogLevel(const std::string& levelStr, bool applyToFile = false) {
+        auto lvl = spdlog::level::from_str(levelStr);
+        setLevel(lvl, applyToFile);
+    }
+
+    void setLogLevelFromEnv(const std::string& envKey = "AYON_USD_RESOLVER_LOG_LVL", bool applyToFile = false) {
+        auto envVal = std::getenv(envKey.c_str());
+        if (envVal) {
+            setLogLevel(std::string(envVal), applyToFile);
+        }
+    }
+
     void setLogLevelInfo(bool applyToFile = false) {
         setLevel(spdlog::level::info, applyToFile);
     }

--- a/src/lib/ynput/lib/logging/AyonLogger.hpp
+++ b/src/lib/ynput/lib/logging/AyonLogger.hpp
@@ -5,6 +5,8 @@
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <iostream>
 #include <memory>
@@ -162,7 +164,13 @@ public:
     }
 
     void setLogLevel(const std::string& levelStr, bool applyToFile = false) {
-        auto lvl = spdlog::level::from_str(levelStr);
+        auto normalizedLevel = levelStr;
+        std::transform(
+            normalizedLevel.begin(),
+            normalizedLevel.end(),
+            normalizedLevel.begin(),
+            ::tolower);
+        auto lvl = spdlog::level::from_str(normalizedLevel);
         setLevel(lvl, applyToFile);
     }
 

--- a/src/lib/ynput/lib/logging/AyonLogger.hpp
+++ b/src/lib/ynput/lib/logging/AyonLogger.hpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -30,8 +31,10 @@
 class AyonLogger {
 public:
     static AyonLogger& getInstance() {
-        static AyonLogger instance;
-        return instance;
+        // Keep the logger alive until process exit. DLL-local static destruction
+        // order in host applications can be unsafe during shutdown on Windows.
+        static auto* instance = new AyonLogger();
+        return *instance;
     }
 
     // Explicit Initialization for File Logging
@@ -50,6 +53,14 @@ public:
 
         std::cout << "[AyonLogger] Initializing async file logger at: " << filepath << std::endl;
         try {
+            auto abs_path = std::filesystem::absolute(filepath).string();
+            {
+                std::ofstream probe(abs_path, std::ios::app);
+                if (!probe.is_open()) {
+                    throw std::runtime_error("Failed opening file " + abs_path + " for writing");
+                }
+            }
+
             // Initialize async thread pool only if not already initialized
             // (another component may have already called spdlog::init_thread_pool)
             if (!spdlog::thread_pool()) {
@@ -57,7 +68,6 @@ public:
             }
             m_fileLoggerThreadPool = spdlog::thread_pool();
 
-            auto abs_path = std::filesystem::absolute(filepath).string();
             std::string logger_name = std::string("AyonLogger_file_logger_") + abs_path;
 
             m_fileLogger = spdlog::basic_logger_mt<spdlog::async_factory>(
@@ -169,7 +179,7 @@ public:
             normalizedLevel.begin(),
             normalizedLevel.end(),
             normalizedLevel.begin(),
-            ::tolower);
+            [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
         auto lvl = spdlog::level::from_str(normalizedLevel);
         setLevel(lvl, applyToFile);
     }
@@ -178,7 +188,7 @@ public:
         auto envVal = std::getenv(envKey.c_str());
         if (envVal) {
             setLogLevel(std::string(envVal), applyToFile);
-            std::cout << "[AyonLogger] Log level set from environment variable '" << envKey 
+            std::cout << "[AyonLogger] Log level set from environment variable '" << envKey
                       << "' with value '" << envVal << "'" << std::endl;
         }
     }

--- a/src/lib/ynput/lib/logging/AyonLogger.hpp
+++ b/src/lib/ynput/lib/logging/AyonLogger.hpp
@@ -170,6 +170,8 @@ public:
         auto envVal = std::getenv(envKey.c_str());
         if (envVal) {
             setLogLevel(std::string(envVal), applyToFile);
+            std::cout << "[AyonLogger] Log level set from environment variable '" << envKey 
+                      << "' with value '" << envVal << "'" << std::endl;
         }
     }
 


### PR DESCRIPTION
## Changelog Description
This pull request makes several improvements to the `AyonLogger` class to enhance logger lifetime management, file logging initialization, and log level configuration. The most notable changes include modifying the singleton pattern to ensure safe destruction, adding robust file logger initialization, and providing more flexible log level setting options.

**Logger Lifetime and Initialization:**

* Changed the singleton implementation in `AyonLogger::getInstance()` to use a heap-allocated static instance, preventing unsafe destruction order issues during DLL unloading on Windows.
* Improved file logger initialization by explicitly checking file writability before logger creation, throwing a clear error if the file cannot be opened.

**Log Level Configuration:**

* Added overloaded `setLogLevel` methods to support setting the log level via both `spdlog::level::level_enum` and string values, with case-insensitive string normalization.
* Added `setLogLevelFromEnv` method to allow automatic log level configuration from an environment variable, improving deployment flexibility.

**Other Code Quality Improvements:**

* Included additional standard headers (`<algorithm>`, `<cctype>`, `<fstream>`) to support new functionality.

## Testing notes:
Tested already.
